### PR TITLE
Ease communication between view controllers ?

### DIFF
--- a/lib/view-controller/view-controller-stack.js
+++ b/lib/view-controller/view-controller-stack.js
@@ -45,6 +45,7 @@ var ViewControllerStack = moobile.ViewControllerStack = new Class({
 
 		var viewControllerPushed = viewController;
 		var viewControllerBefore = childViewControllers.getLastItemAtOffset(1);
+		viewControllerPushed.setPusher(viewControllerBefore);
 
 		var viewToShow = viewControllerPushed.getView();
 		var viewToHide = viewControllerBefore

--- a/lib/view-controller/view-controller.js
+++ b/lib/view-controller/view-controller.js
@@ -861,9 +861,9 @@ var ViewController = moobile.ViewController = new Class({
 	}
 
 	/**
-	 * @see    http://moobilejs.com/doc/latest/ViewController/ViewControllerStack#getTopViewController
+	 * @see    http://moobilejs.com/doc/latest/ViewController/ViewControllerStack#setPusher
 	 * @author Tin LE GALL (imbibinebe@gmail.com)
-	 * @since  0.1.0
+	 * @since  0.3.0
 	 */
 	setPusher: function(pusher) {
 		this.__pusher = pusher;
@@ -871,9 +871,9 @@ var ViewController = moobile.ViewController = new Class({
 	},
 
 	/**
-	 * @see    http://moobilejs.com/doc/latest/ViewController/ViewControllerStack#getTopViewController
+	 * @see    http://moobilejs.com/doc/latest/ViewController/ViewControllerStack#getPusher
 	 * @author Tin LE GALL (imbibinebe@gmail.com)
-	 * @since  0.1.0
+	 * @since  0.3.0
 	 */
 	getPusher: function() {
 		return this.__pusher;

--- a/lib/view-controller/view-controller.js
+++ b/lib/view-controller/view-controller.js
@@ -61,6 +61,13 @@ var ViewController = moobile.ViewController = new Class({
 
 	/**
 	 * @hidden
+	 * @author Tin LE GALL (imbibinebe@gmail.com)
+	 * @since  0.3.0
+	 */
+	__pusher: null,
+
+	/**
+	 * @hidden
 	 * @author Jean-Philippe Dery (jeanphilippe.dery@gmail.com)
 	 * @since  0.1.0
 	 */
@@ -852,5 +859,25 @@ var ViewController = moobile.ViewController = new Class({
 
 		this.viewDidRotate(name);
 	}
+
+	/**
+	 * @see    http://moobilejs.com/doc/latest/ViewController/ViewControllerStack#getTopViewController
+	 * @author Tin LE GALL (imbibinebe@gmail.com)
+	 * @since  0.1.0
+	 */
+	setPusher: function(pusher) {
+		this.__pusher = pusher;
+		return this;
+	},
+
+	/**
+	 * @see    http://moobilejs.com/doc/latest/ViewController/ViewControllerStack#getTopViewController
+	 * @author Tin LE GALL (imbibinebe@gmail.com)
+	 * @since  0.1.0
+	 */
+	getPusher: function() {
+		return this.__pusher;
+	},
+
 
 });


### PR DESCRIPTION
In a view controller, it is not uncommon that we want to retrieve data/variables from the view controller it was pushed from. However, it is not that easy to do so by using ViewControllerStack.

exemple:
VC1 pushes VC2 (VCS = [VC1 VC2])

In its viewWillEnter method, VC2 gets data from a server depending on a VC1 variable. To achieve this, it can do the following to get VC1:
this.getViewControllerStack().getChildViewControllers().getLastItemAtOffset(1) returns VC1

then, VC2 pushes VC3 (VCS = [VC1 VC2 VC3])
VC3 do some stuff and pops back to VC2.
In its viewWillEnter VC2 tries again to get data from a server depending on a VC1 variable. However, VCS is still equal to [VC1 VC2 VC3] and then 
this.getViewControllerStack().getChildViewControllers().getLastItemAtOffset(1) returns VC2 itself ... we have a problem :)

That's why i suggest you these modifications:

If VC[i] needs to access VC[i-1] it has just to call this.getPusher(), whatever the method it is called from (viewDidLoad, viewWillEnter, viewDidEnter ...)

If VC[i] needs to acces VC[i-2] it has just to call this.getPusher().getPusher() and so on.

What do you think ?



